### PR TITLE
Adding multi promise handler

### DIFF
--- a/addon/helpers/multi-promise-handler.js
+++ b/addon/helpers/multi-promise-handler.js
@@ -1,5 +1,5 @@
 import Helper from '@ember/component/helper';
-
+import { hashSettled } from 'rsvp';
 /**
  * This is the multi-promise-handler helper. It allows for passing in multiple network requests, while offering the
  * ability to gracefully handle the response for each promise. The output would thus still leverage the suspense
@@ -13,16 +13,16 @@ import Helper from '@ember/component/helper';
  *     {{#if task.isLoading}}
  *       <div>Loading...</div>
  *     {{else if task.isSuccess}}
- *       {{#if task.data.promiseOne.isSuccess}}
- *         <div>{{task.data.promiseOne.data.userRequest.name}}
- *       {{else if task.data.promiseOne.isError}}
- *         <div>Error: {{task.data.promiseOne.errorReason}}
+ *       {{#if (eq task.data.promiseOne.state "fulfilled")}}
+ *         <div>{{task.data.promiseOne.value.userRequest.name}}
+ *       {{else if (eq task.data.promiseOne.state "rejected"}}
+ *         <div>Error: {{task.data.promiseOne.reason}}
  *       {{/if}}
  * 
- *       {{#if task.data.promiseTwo.isSuccess}}
- *         <div>{{task.data.promiseTwo.data.userRequest.name}}
- *       {{else if task.data.promiseTwo.isError}}
- *         <div>Error: {{task.data.promiseTwo.errorReason}}
+ *       {{#if (eq task.data.promiseTwo.state "fulfilled")}}
+ *         <div>{{task.data.promiseTwo.value.userRequest.name}}
+ *       {{else (eq if task.data.promiseTwo.state "rejected"}}
+ *         <div>Error: {{task.data.promiseTwo.reason}}
  *       {{/if}}
  *     {{else if task.isError}}
  *       <div>Error occurred: {{task.errorReason}}</div>
@@ -30,35 +30,7 @@ import Helper from '@ember/component/helper';
  *   {{/suspense-component}}
  */
 export default Helper.extend({
-  promiseCallback(promises, payload) {
-    if (promises.length) {
-      const [currentPromiseCategory, currentPromise] = promises.pop();
-      return currentPromise
-      .then((resolvedPromise) => this.successCallback(resolvedPromise, promises, currentPromiseCategory, payload))
-      .catch((resolvedPromise) => this.failCallback(resolvedPromise, promises, currentPromiseCategory, payload));
-    }
-    return payload;
-  },
-  successCallback(resolvedPromise, promises, category, payload) {
-    payload[category] = {
-      data: resolvedPromise,
-      isSuccess: true,
-      isError: false,
-      errorReason: null
-    }
-    return this.promiseCallback(promises, payload);
-  },
-  failCallback(resolvedPromise, promises, category, payload) {
-    payload[category] = {
-      data: null,
-      isSuccess: false,
-      isError: true,
-      errorReason: resolvedPromise
-    }
-    return this.promiseCallback(promises, payload);
-  },
-  compute(args, promisesObj) {
-    const promises = Object.entries(promisesObj);
-    return this.promiseCallback(promises, {});
+  compute(args, hash) {
+    return hashSettled(hash);
   }
 });

--- a/addon/helpers/multi-promise-handler.js
+++ b/addon/helpers/multi-promise-handler.js
@@ -1,0 +1,64 @@
+import Helper from '@ember/component/helper';
+
+/**
+ * This is the multi-promise-handler helper. It allows for passing in multiple network requests, while offering the
+ * ability to gracefully handle the response for each promise. The output would thus still leverage the suspense
+ * component data schema, but embedded to each response, there will be an assigned state.
+ * @example
+ *   {{#suspense-component
+ *     promise=(ember-async-component$multi-promise-handler promiseOne=promise.first promiseTwo=promise.second)
+ *     blockRender=false
+ *     as |task|
+ *   }}
+ *     {{#if task.isLoading}}
+ *       <div>Loading...</div>
+ *     {{else if task.isSuccess}}
+ *       {{#if task.data.promiseOne.isSuccess}}
+ *         <div>{{task.data.promiseOne.data.userRequest.name}}
+ *       {{else if task.data.promiseOne.isError}}
+ *         <div>Error: {{task.data.promiseOne.errorReason}}
+ *       {{/if}}
+ * 
+ *       {{#if task.data.promiseTwo.isSuccess}}
+ *         <div>{{task.data.promiseTwo.data.userRequest.name}}
+ *       {{else if task.data.promiseTwo.isError}}
+ *         <div>Error: {{task.data.promiseTwo.errorReason}}
+ *       {{/if}}
+ *     {{else if task.isError}}
+ *       <div>Error occurred: {{task.errorReason}}</div>
+ *     {{/if}}
+ *   {{/suspense-component}}
+ */
+export default Helper.extend({
+  promiseCallback(promises, payload) {
+    if (promises.length) {
+      const [currentPromiseCategory, currentPromise] = promises.pop();
+      return currentPromise
+      .then((resolvedPromise) => this.successCallback(resolvedPromise, promises, currentPromiseCategory, payload))
+      .catch((resolvedPromise) => this.failCallback(resolvedPromise, promises, currentPromiseCategory, payload));
+    }
+    return payload;
+  },
+  successCallback(resolvedPromise, promises, category, payload) {
+    payload[category] = {
+      data: resolvedPromise,
+      isSuccess: true,
+      isError: false,
+      errorReason: null
+    }
+    return this.promiseCallback(promises, payload);
+  },
+  failCallback(resolvedPromise, promises, category, payload) {
+    payload[category] = {
+      data: null,
+      isSuccess: false,
+      isError: true,
+      errorReason: resolvedPromise
+    }
+    return this.promiseCallback(promises, payload);
+  },
+  compute(args, promisesObj) {
+    const promises = Object.entries(promisesObj);
+    return this.promiseCallback(promises, {});
+  }
+});

--- a/app/helpers/multi-promise-handler.js
+++ b/app/helpers/multi-promise-handler.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-async-component/helpers/multi-promise-handler';

--- a/tests/integration/helpers/multi-promise-handler-test.js
+++ b/tests/integration/helpers/multi-promise-handler-test.js
@@ -3,7 +3,6 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, waitUntil } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import { defer as Defer } from 'rsvp';
-
 module('Integration | Helper | multi-promise-handler', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -26,14 +25,14 @@ module('Integration | Helper | multi-promise-handler', function (hooks) {
             Loading...
           </div>
         {{else if task.isSuccess}}
-          {{#if task.data.promiseOne.isSuccess}}
+          {{#if (eq task.data.promiseOne.state "fulfilled")}}
             <div data-test-async-success-one>
-              {{task.data.promiseOne.data.name}}
+              {{task.data.promiseOne.value.name}}
             </div>
           {{/if}}
-          {{#if task.data.promiseTwo.isSuccess}}
+          {{#if (eq task.data.promiseTwo.state "fulfilled")}}
             <div data-test-async-success-two>
-              {{task.data.promiseTwo.data.name}}
+              {{task.data.promiseTwo.value.name}}
             </div>
           {{/if}}
         {{else if task.isError}}
@@ -58,7 +57,7 @@ module('Integration | Helper | multi-promise-handler', function (hooks) {
     assert
       .dom(dataSelectorOne)
       .hasText('Harry Potter', 'success section is rendered');
-      assert
+    assert
       .dom(dataSelectorTwo)
       .hasText('Hermoine Granger', 'success section is rendered');
   });
@@ -82,18 +81,18 @@ module('Integration | Helper | multi-promise-handler', function (hooks) {
             Loading...
           </div>
         {{else if task.isSuccess}}
-          {{#if task.data.promiseOne.isSuccess}}
+          {{#if (eq task.data.promiseOne.state "fulfilled")}}
             <div data-test-async-success-one>
-              {{task.data.promiseOne.data.name}}
+              {{task.data.promiseOne.value.name}}
             </div>
           {{/if}}
-          {{#if task.data.promiseTwo.isSuccess}}
+          {{#if (eq task.data.promiseTwo.state "fulfilled")}}
             <div data-test-async-success-two>
-              {{task.data.promiseTwo.data.name}}
+              {{task.data.promiseTwo.value.name}}
             </div>
-          {{else if task.data.promiseTwo.isError}}
+          {{else if (eq task.data.promiseTwo.state "rejected")}}
             <div data-test-async-error-two>
-              {{task.data.promiseTwo.errorReason}}
+              {{task.data.promiseTwo.reason}}
             </div>
           {{/if}}
         {{else if task.isError}}
@@ -112,12 +111,17 @@ module('Integration | Helper | multi-promise-handler', function (hooks) {
     assert
       .dom(loadingSelector)
       .doesNotExist('Expected loading to not be rendered');
-    assert.dom(dataSelectorTwo).doesNotExist('Expected second success to not be rendered');
+    assert
+      .dom(dataSelectorTwo)
+      .doesNotExist('Expected second success to not be rendered');
     assert
       .dom(dataSelectorOne)
       .hasText('Harry Potter', 'success section is rendered for first promise');
-      assert
+    assert
       .dom(dataErrorSelectorTwo)
-      .hasText('Unable to load', 'error section is rendered for second promise');
+      .hasText(
+        'Unable to load',
+        'error section is rendered for second promise'
+      );
   });
 });

--- a/tests/integration/helpers/multi-promise-handler-test.js
+++ b/tests/integration/helpers/multi-promise-handler-test.js
@@ -1,0 +1,123 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, waitUntil } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { defer as Defer } from 'rsvp';
+
+module('Integration | Helper | multi-promise-handler', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('Component renders multiple successfully resolved promises as expected', async function (assert) {
+    const loadingSelector = '[data-test-async-loading]';
+    const errorSelector = '[data-test-async-error]';
+    const dataSelectorOne = '[data-test-async-success-one]';
+    const dataSelectorTwo = '[data-test-async-success-two]';
+    this.deferredOne = new Defer();
+    this.deferredPromiseOne = this.deferredOne.promise;
+    this.deferredTwo = new Defer();
+    this.deferredPromiseTwo = this.deferredTwo.promise;
+    await render(hbs`
+      <Suspense
+        @promise={{multi-promise-handler promiseOne=deferredPromiseOne promiseTwo=deferredPromiseTwo}}
+        as |task|
+      >
+        {{#if task.isLoading}}
+          <div data-test-async-loading>
+            Loading...
+          </div>
+        {{else if task.isSuccess}}
+          {{#if task.data.promiseOne.isSuccess}}
+            <div data-test-async-success-one>
+              {{task.data.promiseOne.data.name}}
+            </div>
+          {{/if}}
+          {{#if task.data.promiseTwo.isSuccess}}
+            <div data-test-async-success-two>
+              {{task.data.promiseTwo.data.name}}
+            </div>
+          {{/if}}
+        {{else if task.isError}}
+          <div data-test-async-error>
+            Error message...
+          </div>
+        {{/if}}
+      </Suspense>
+    `);
+    assert.dom(loadingSelector).exists('loading is rendered');
+    this.deferredOne.resolve({
+      name: 'Harry Potter'
+    });
+    this.deferredTwo.resolve({
+      name: 'Hermoine Granger'
+    });
+    await waitUntil(() => !find(loadingSelector));
+    assert
+      .dom(loadingSelector)
+      .doesNotExist('Expected loading to not be rendered');
+    assert.dom(errorSelector).doesNotExist('Expected error to not be rendered');
+    assert
+      .dom(dataSelectorOne)
+      .hasText('Harry Potter', 'success section is rendered');
+      assert
+      .dom(dataSelectorTwo)
+      .hasText('Hermoine Granger', 'success section is rendered');
+  });
+
+  test('Component renders partially successfully batches as expected', async function (assert) {
+    const loadingSelector = '[data-test-async-loading]';
+    const dataSelectorOne = '[data-test-async-success-one]';
+    const dataSelectorTwo = '[data-test-async-success-two]';
+    const dataErrorSelectorTwo = '[data-test-async-error-two]';
+    this.deferredOne = new Defer();
+    this.deferredPromiseOne = this.deferredOne.promise;
+    this.deferredTwo = new Defer();
+    this.deferredPromiseTwo = this.deferredTwo.promise;
+    await render(hbs`
+      <Suspense
+        @promise={{multi-promise-handler promiseOne=deferredPromiseOne promiseTwo=deferredPromiseTwo}}
+        as |task|
+      >
+        {{#if task.isLoading}}
+          <div data-test-async-loading>
+            Loading...
+          </div>
+        {{else if task.isSuccess}}
+          {{#if task.data.promiseOne.isSuccess}}
+            <div data-test-async-success-one>
+              {{task.data.promiseOne.data.name}}
+            </div>
+          {{/if}}
+          {{#if task.data.promiseTwo.isSuccess}}
+            <div data-test-async-success-two>
+              {{task.data.promiseTwo.data.name}}
+            </div>
+          {{else if task.data.promiseTwo.isError}}
+            <div data-test-async-error-two>
+              {{task.data.promiseTwo.errorReason}}
+            </div>
+          {{/if}}
+        {{else if task.isError}}
+          <div data-test-async-error>
+            Error message...
+          </div>
+        {{/if}}
+      </Suspense>
+    `);
+    assert.dom(loadingSelector).exists('loading is rendered');
+    this.deferredOne.resolve({
+      name: 'Harry Potter'
+    });
+    this.deferredTwo.reject('Unable to load');
+    await waitUntil(() => !find(loadingSelector));
+    assert
+      .dom(loadingSelector)
+      .doesNotExist('Expected loading to not be rendered');
+    assert.dom(dataSelectorTwo).doesNotExist('Expected second success to not be rendered');
+    assert
+      .dom(dataSelectorOne)
+      .hasText('Harry Potter', 'success section is rendered for first promise');
+      assert
+      .dom(dataErrorSelectorTwo)
+      .hasText('Unable to load', 'error section is rendered for second promise');
+  });
+});


### PR DESCRIPTION
This is the multi-promise-handler helper. It allows for passing in multiple network requests, while offering the ability to gracefully handle the response for each promise.
The output would thus still leverage the suspense component data schema, but embedded to each response, there will be an assigned state.

---ember test---

ok 1 Chrome 86.0 - [216 ms] - Integration | Component | suspense-component: Component renders in success case as expected
ok 2 Chrome 86.0 - [62 ms] - Integration | Component | suspense-component: Component renders in error case as expected
ok 3 Chrome 86.0 - [64 ms] - Integration | Component | suspense-component: Component renders in success case as expected in the fastboot case
ok 4 Chrome 86.0 - [64 ms] - Integration | Helper | multi-promise-handler: Component renders multiple successfully resolved promises as expected
ok 5 Chrome 86.0 - [60 ms] - Integration | Helper | multi-promise-handler: Component renders partially successfully batches as expected
ok 6 Chrome 86.0 - [0 ms] - ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly

1..6
tests 6
pass 6
skip 0
todo 0
fail 0
ok