### PR TITLE
Set loading state of task before adding to `this`

### DIFF
--- a/addon/components/suspense/index.js
+++ b/addon/components/suspense/index.js
@@ -78,13 +78,13 @@ export default class Suspense extends Component {
       return task;
     }
 
+    task.isLoading = true;
+
     // TODO: Fix these linting errors, getters shouldn't have side effects
     // eslint-disable-next-line ember/no-side-effects
     this.task = task;
     // eslint-disable-next-line ember/no-side-effects
     this.promise = promise;
-
-    task.isLoading = true;
 
     if (blockRender && this.fastboot.isFastBoot) {
       // https://github.com/ember-fastboot/ember-cli-fastboot#delaying-the-server-response


### PR DESCRIPTION
`this.task = task` can start a new render loop, so setting `task.isLoading` immediately after throws an error for modifying the object twice in the same render loop.

We still need to deal with the sets themselves, but for now moving this can fix one of the errors thrown.