### PR TITLE
Destructure hash in multi-promise-handler

### DIFF
--- a/addon/helpers/multi-promise-handler.js
+++ b/addon/helpers/multi-promise-handler.js
@@ -31,6 +31,6 @@ import { hashSettled } from 'rsvp';
  */
 export default class MultiPromiseHandler extends Helper {
   compute(args, hash) {
-    return hashSettled(hash);
+    return hashSettled({ ...hash });
   }
 }


### PR DESCRIPTION
This is a workaround to ensure the identity of the hash changes when its properties are updated. Currently, the properties may change but the hash identity stays the same, so updates don't fully propagate in the latest versions of Ember. It's unclear if this will be the long-term fix, but this solves the issue we have for now until further investigation can be done.