### PR TITLE
Print error to console instead of swallowing during tests

### DIFF
--- a/addon/components/suspense/index.js
+++ b/addon/components/suspense/index.js
@@ -101,7 +101,9 @@ export default class Suspense extends Component {
         task.errorReason = e;
         task.isLoading = false;
         // https://github.com/emberjs/ember.js/issues/15569
-        if (!Ember.testing) {
+        if (Ember.testing) {
+          console.error(e);
+        } else {
           throw e;
         }
       }


### PR DESCRIPTION
Suspense is swallowing errors during testing, making it difficult to identify that the cause of a problem is happening in an async function. This will at least print the console to the error. 

Potentially we can remove [this condition](https://github.com/sunishsheth2009/ember-async-component/blob/master/addon/components/suspense/index.js#L104) altogether and simply throw the error. 

With this PR, it will print the error to the console, but it won't surface any errors in the UI of the qunit testing interface.  If we throw the error, it will show the error message directly in the UI of the browser.

[This is the issue](https://github.com/emberjs/ember.js/issues/15569) from ember v2 that motivated the `Ember.testing` condition.  